### PR TITLE
Storing lambda on the full mesh helped with fixing the restart in sim…

### DIFF
--- a/Sources/Modules/read_wout_mod.f90
+++ b/Sources/Modules/read_wout_mod.f90
@@ -94,7 +94,7 @@
         vn_bsupumns_sur = 'bsupumns_sur',                               &
         vn_bsupvmns_sur = 'bsupvmns_sur',                               &
         vn_rbc = 'rbc', vn_zbs = 'zbs', vn_rbs = 'rbs', vn_zbc = 'zbc', &
-        vn_mnyq = 'mnyq', vn_nnyq = 'nnyq'
+        vn_mnyq = 'mnyq', vn_nnyq = 'nnyq', vn_xc = 'xc'
 ! Long names (ln_...)
       CHARACTER(LEN=*), PARAMETER :: ln_version = 'VMEC Version',       &
         ln_extension = 'Input file extension', ln_mgrid = 'MGRID file', &
@@ -213,7 +213,8 @@
         ln_rbs = 'Initial boundary R sin(mu-nv) coefficients',          &
         ln_zbc = 'Initial boundary Z cos(mu-nv) coefficients',          &
         ln_mnyq = 'Poloidal modes (Nyquist)',                           &
-        ln_nnyq = 'Toroidal modes (Nyquist)'
+        ln_nnyq = 'Toroidal modes (Nyquist)',                           &
+        ln_xc = 'internal state array'
 #endif
 !-----------------------------------------------
 !   L o c a l   V a r i a b l e s


### PR DESCRIPTION
…ple cases but still didn't restart well in more complex cases. Instead store the xc array directly.