### PR TITLE
Changes for thread safety

### DIFF
--- a/Sources/Modules/bsc_T.f
+++ b/Sources/Modules/bsc_T.f
@@ -1403,8 +1403,13 @@
          CALL bsc_a_coil(this(i),x,aarray(1:3,i))
       END DO
 
-! Sum for A field
-      a(1:3) = SUM(aarray(1:3,1:n),2)
+! Sum for A field (explicit loop: reproducible with OpenMP; avoid parallel SUM)
+      a(1) = zero; a(2) = zero; a(3) = zero
+      DO i = 1, n
+         a(1) = a(1) + aarray(1,i)
+         a(2) = a(2) + aarray(2,i)
+         a(3) = a(3) + aarray(3,i)
+      END DO
       
 !  Rescale if bsc_k2 present
       IF (PRESENT(bsc_k2)) THEN
@@ -1710,8 +1715,13 @@
          CALL bsc_b_coil(this(i),x,barray(1:3,i))
       END DO
 
-! Sum for B field
-      b = SUM(barray(1:3,1:n),2)
+! Sum for B field (explicit loop: reproducible with OpenMP; avoid parallel SUM)
+      b(1) = zero; b(2) = zero; b(3) = zero
+      DO i = 1, n
+         b(1) = b(1) + barray(1,i)
+         b(2) = b(2) + barray(2,i)
+         b(3) = b(3) + barray(3,i)
+      END DO
       
 !  Rescale if bsc_k2 present
       IF (PRESENT(bsc_k2)) THEN


### PR DESCRIPTION
1. Files changed in the repository

Two areas were modified: MAKEGRID (compute_bfield in [MAKEGRID/Sources/write_mgrid.f] and LIBSTELL ([LIBSTELL/Sources/Modules/bsc_T.f].

A. [write_mgrid.f] — SUBROUTINE compute_bfield

Problem: With multiple OpenMP threads, results differed from a single-thread run: NetCDF B and A components that should be exactly zero (for a constructed cancellation case) showed small non-zeros. Serial OMP_NUM_THREADS=1matched expectations; parallel runs did not. Investigation showed concurrent calls to bfield / afield (which call into libstellBiot–Savart) were not safe to execute in parallel on the current code path.

Changes:

LSTELL_SYM = .false. (full toroidal / no Z symmetry shortcut)

Replaced the older multi-!$omp do structure with a single !$omp parallel / !$omp do collapse(3) schedule(static) over DO k / DO j / DO i, with phi / zee / rad computed in the innermost loop so Intel Fortran’s collapse(3) rules (“perfectly nested loops”) are satisfied (and the directive was split across lines to satisfy fixed-form / compiler parsing). 

Wrapped CALL bfield and CALL afield in !$omp critical(mgrid_bs_eval) … !$omp end critical(mgrid_bs_eval) so Biot–Savart evaluation is serialized and output matches single-thread behavior for this test.

LSTELL_SYM = .true. (stellarator symmetry fill)

The symmetry branch still uses the original three-block layout (half Z, interior phi, optional extra plane). Initially it lacked the same critical wrapper; non-zero residuals appeared only in symmetric runs under OpenMP. 

Added the same mgrid_bs_eval critical region around each bfield + mirror assignments + afield + mirror assignments sequence in all three symmetry loops, so parallel runs agree with serial runs for the cancellation tests.

Trade-off: The critical regions limit parallel speedup for the field evaluation itself, until libstell can be proven (or refactored to be) thread-safe for concurrent bfield/afield calls; the loops still structure work for future removal of the critical if the library is fixed.

B. [bsc_T.f]— bsc_a_coil_a and bsc_b_coil_a

Problem: Summing coil contributions with SUM(array, dim=2) can use compiler/library optimizations (vectorization, parallel reductions) whose evaluation order can differ from a simple sequential sum. For near-cancellation cases (opposing currents), that can change floating-point results; this was an extra guard for reproducibility when OpenMP is enabled.

Change: Replaced
a(1:3) = SUM(aarray(1:3,1:n),2) and b = SUM(barray(1:3,1:n),2) with explicit DO loops that accumulate a(1:3) and b(1:3) coil-by-coil in a fixed order, initialized from zero.

Note: The dominant parallel bug was addressed by critical in compute_bfield; the explicit sums are a robustnessimprovement and do not replace the need for thread-safe Biot–Savart if critical is removed later.
